### PR TITLE
Fix buffer assignment in block matmul implementation (matmul_part3.ipynb)

### DIFF
--- a/source/matmult/notebook/matmul_part3.ipynb
+++ b/source/matmult/notebook/matmul_part3.ipynb
@@ -529,9 +529,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "block.write(block.register_map.in1_1.address, input1_buffer0.physical_address)\n",
-    "block.write(block.register_map.in2_1.address, input2_buffer0.physical_address)\n",
-    "block.write(block.register_map.out_r_1.address, output_buffer0.physical_address)\n",
+    "block.write(block.register_map.in1_1.address, input1_buffer1.physical_address)\n",
+    "block.write(block.register_map.in2_1.address, input2_buffer1.physical_address)\n",
+    "block.write(block.register_map.out_r_1.address, output_buffer1.physical_address)\n",
     "block.write(block.register_map.dim.address, dim0)"
    ]
   },


### PR DESCRIPTION
The block matmul implementation was using the baseline buffers instead of the newly allocated buffers, resulting in incorrect output. 

This PR fixes the buffer assignment in the block implementation.

![image](https://github.com/user-attachments/assets/f4d62739-35d7-48c6-8cd2-7fc9417ee680)

![image](https://github.com/user-attachments/assets/791da848-b859-4241-9ced-410200422b48)
